### PR TITLE
Use region provided by secret-service client

### DIFF
--- a/R/reports.R
+++ b/R/reports.R
@@ -222,7 +222,7 @@ wait_and_check <- function(report_object) {
         bucket = report_object$active_version$report_bucket,
         key = datasets_credentials$access_key,
         secret = datasets_credentials$secret_key,
-        region = "eu-west-1", check_region = FALSE
+        region = datasets_credentials$region
       ) %>% utils::head(1)
       && filtered_reports$status == "success"
     ) {
@@ -247,8 +247,6 @@ update_report_text <- function(report_path, report_object) {
     # credentials
     key = datasets_credentials$access_key,
     secret = datasets_credentials$secret_key,
-    # encryption
-    headers = c("x-amz-server-side-encryption" = "AES256"),
-    region = "eu-west-1", check_region = FALSE
+    region = datasets_credentials$region
   )
 }

--- a/R/reports.R
+++ b/R/reports.R
@@ -222,7 +222,8 @@ wait_and_check <- function(report_object) {
         bucket = report_object$active_version$report_bucket,
         key = datasets_credentials$access_key,
         secret = datasets_credentials$secret_key,
-        region = datasets_credentials$region
+        region = datasets_credentials$region,
+        check_region = FALSE
       ) %>% utils::head(1)
       && filtered_reports$status == "success"
     ) {
@@ -247,6 +248,7 @@ update_report_text <- function(report_path, report_object) {
     # credentials
     key = datasets_credentials$access_key,
     secret = datasets_credentials$secret_key,
-    region = datasets_credentials$region
+    region = datasets_credentials$region,
+    check_region = FALSE
   )
 }

--- a/tests/testthat/test-reports.R
+++ b/tests/testthat/test-reports.R
@@ -46,7 +46,8 @@ test_that(
       bucket='dummy-bucket',
       key='dummy-key',
       secret='dummy-secret',
-      region='dummy-region'
+      region='dummy-region',
+      check_region=FALSE
     )
   }
 )

--- a/tests/testthat/test-reports.R
+++ b/tests/testthat/test-reports.R
@@ -11,7 +11,8 @@ dummy_report_object <- list(active_version=list(report_path='/s3-path'),
                             report_name=dummy_report_name)
 dummy_datasets_credentials <- list(access_key='dummy-key',
                                    secret_key='dummy-secret',
-                                   bucket='dummy-bucket')
+                                   bucket='dummy-bucket',
+                                   region='dummy-region')
 
 inp_file <- file(test_path('fixtures/test_tavern_report_list.json'))
 json_text <- readLines(inp_file)
@@ -45,9 +46,7 @@ test_that(
       bucket='dummy-bucket',
       key='dummy-key',
       secret='dummy-secret',
-      headers=c("x-amz-server-side-encryption" = "AES256"),
-      region='eu-west-1',
-      check_region=FALSE
+      region='dummy-region'
     )
   }
 )


### PR DESCRIPTION
This PR removes the hardcoded `eu-west-1` region and uses the region provided by the secret service when requesting the S3 credentials. I've also taken the opportunity to remove the header to use `AES256` server side encryption as we are not specifying that through bucket default encryption as opposed to setting it on the clients.