### PR TITLE
Remove get_datasets_credentials

### DIFF
--- a/R/authentication.R
+++ b/R/authentication.R
@@ -52,22 +52,3 @@ set_user_id <- function() {
 add_hudson_header <- function() {
   httr::add_headers(Authorization = getOption("faculty.hudson.token"))
 }
-
-get_datasets_credentials <- function() {
-  set_hudson_token()
-
-  getOption("faculty.secret_url") %>%
-  paste("hoard", Sys.getenv("FACULTY_PROJECT_ID"), sep = "/") %>%
-    httr::GET(httr::add_headers(
-      Authorization = getOption("faculty.hudson.token")
-    )) %>%
-    httr::content(as = "parsed", type = "application/json") ->
-    datasets_credentials
-
-  if (!is.null(datasets_credentials) && datasets_credentials$verified) {
-      return(datasets_credentials)
-  } else {
-      Sys.sleep(5)
-      return(get_datasets_credentials())
-  }
-}

--- a/R/authentication.R
+++ b/R/authentication.R
@@ -57,7 +57,7 @@ get_datasets_credentials <- function() {
   set_hudson_token()
 
   getOption("faculty.secret_url") %>%
-  paste("sfs", Sys.getenv("FACULTY_PROJECT_ID"), sep = "/") %>%
+  paste("hoard", Sys.getenv("FACULTY_PROJECT_ID"), sep = "/") %>%
     httr::GET(httr::add_headers(
       Authorization = getOption("faculty.hudson.token")
     )) %>%

--- a/R/reports.R
+++ b/R/reports.R
@@ -202,8 +202,6 @@ publish_new_version <- function(name, report_path) {
 
 wait_and_check <- function(report_object) {
 
-  datasets_credentials <- get_datasets_credentials()
-
   repeat {
 
     filtered_reports <-

--- a/tests/testthat/test-authentication.R
+++ b/tests/testthat/test-authentication.R
@@ -97,53 +97,8 @@ test_that(
 )
 
 test_that(
-  "datasets credentials are retrieved from the right place", {
-    httptest::with_mock_api({
-      mockery::stub(get_datasets_credentials, "set_hudson_token", mock(NULL))
-      httptest::expect_GET(
-        get_datasets_credentials(),
-        url = paste(getOption("faculty.secret_url"),
-                    "sfs", Sys.getenv("FACULTY_PROJECT_ID"),
-                    sep = "/")
-      )
-    })
-  }
-)
-
-test_that(
   "auth headers are actual headers", {
     mockery::stub(add_hudson_header, "httr::add_headers", mock("dummy-header"))
     expect_equal(add_hudson_header(), "dummy-header")
-  }
-)
-
-test_that(
-  "datasets credentials are retrieved from the right place", {
-    mockery::stub(
-      get_datasets_credentials,
-      "set_hudson_token",
-      mock(NULL, cycle = TRUE)
-    )
-
-    mock_get <- mock(NULL, cycle = TRUE)
-    mockery::stub(get_datasets_credentials, "httr::GET", mock_get)
-
-    mock_parse_content <- mock(list(verified = FALSE))
-    mockery::stub(get_datasets_credentials, "httr::content", mock_parse_content)
-
-    # this is a recursive lad, so we can mock it inside itself
-    mockery::stub(
-      get_datasets_credentials,
-      "get_datasets_credentials",
-      mock(list(verified = TRUE))
-    )
-    # mock sleeping so we don"t fall asleep ourselves:
-    mockery::stub(get_datasets_credentials, "Sys.sleep", mock(NULL))
-
-    expect_equal(get_datasets_credentials(), list(verified = TRUE))
-
-    mock_parse_content <- mock(list(verified = TRUE))
-    mockery::stub(get_datasets_credentials, "httr::content", mock_parse_content)
-    expect_equal(get_datasets_credentials(), list(verified = TRUE))
   }
 )

--- a/tests/testthat/test-reports.R
+++ b/tests/testthat/test-reports.R
@@ -28,11 +28,6 @@ test_that(
   {
 
     mockery::stub(wait_and_check, 'Sys.sleep', NULL)
-    mockery::stub(
-      wait_and_check,
-      'get_datasets_credentials',
-      dummy_datasets_credentials
-    )
 
     mock_s3_head <- mock(TRUE)
 

--- a/tests/testthat/test-reports.R
+++ b/tests/testthat/test-reports.R
@@ -24,13 +24,8 @@ dummy_tavern_response <- jsonlite::fromJSON(json_text)
 dummy_report <- test_path("fixtures/test_report.Rmd")
 
 test_that(
-  "wait and check make the correct s3 calls",
+  "wait and check makes the correct calls",
   {
-
-    mockery::stub(wait_and_check, 'Sys.sleep', NULL)
-
-    mock_s3_head <- mock(TRUE)
-
     mockery::stub(wait_and_check, 'datasets_list', list(dummy_remote_report_path))
 
     mockery::stub(


### PR DESCRIPTION
This was used with sfs, but now that hoard is in place it is unneeded 